### PR TITLE
Display error message when opening second instance

### DIFF
--- a/FlashpointSecurePlayer/FlashpointSecurePlayerGUI.cs
+++ b/FlashpointSecurePlayer/FlashpointSecurePlayerGUI.cs
@@ -74,6 +74,7 @@ namespace FlashpointSecurePlayer {
                 }
             } catch (InvalidOperationException ex) {
                 LogExceptionToLauncher(ex);
+                MessageBox.Show(ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             } finally {
                 if (!createdNew) {
                     Environment.Exit(-2);

--- a/FlashpointSecurePlayer/FlashpointSecurePlayerGUI.cs
+++ b/FlashpointSecurePlayer/FlashpointSecurePlayerGUI.cs
@@ -74,9 +74,9 @@ namespace FlashpointSecurePlayer {
                 }
             } catch (InvalidOperationException ex) {
                 LogExceptionToLauncher(ex);
-                MessageBox.Show(ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             } finally {
                 if (!createdNew) {
+                    MessageBox.Show(Properties.Resources.NoMultipleInstances, Properties.Resources.FlashpointSecurePlayer, MessageBoxButtons.OK, MessageBoxIcon.Error);
                     Environment.Exit(-2);
                 }
             }

--- a/FlashpointSecurePlayer/Properties/Resources.Designer.cs
+++ b/FlashpointSecurePlayer/Properties/Resources.Designer.cs
@@ -272,6 +272,15 @@ namespace FlashpointSecurePlayer.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to You cannot run multiple instances of Flashpoint Secure Player..
+        /// </summary>
+        internal static string NoMultipleInstances {
+            get {
+                return ResourceManager.GetString("NoMultipleInstances", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The CPU&apos;s clock speed could not be determined..
         /// </summary>
         internal static string OCS_CPUSpeedNotDetermined {

--- a/FlashpointSecurePlayer/Properties/Resources.resx
+++ b/FlashpointSecurePlayer/Properties/Resources.resx
@@ -190,6 +190,9 @@ If you choose No, the application will exit.</value>
   <data name="NoModeSelected" xml:space="preserve">
     <value>No mode was selected.</value>
   </data>
+  <data name="NoMultipleInstances" xml:space="preserve">
+    <value>You cannot run multiple instances of Flashpoint Secure Player.</value>
+  </data>
   <data name="OCS_CPUSpeedNotDetermined" xml:space="preserve">
     <value>The CPU's clock speed could not be determined.</value>
   </data>


### PR DESCRIPTION
This replicates the functionality provided by the batch files, just without the redundancy. Will hopefully bring us closer to getting rid of them altogether.

I wasn't able to test this because I don't have Visual Studio 2019, ~~but it's a one-line change so I imagine it'll be fine~~ nevermind.